### PR TITLE
Jooby, Koin and modularisation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,10 @@ allprojects {
         mavenCentral()
     }
 
-
     tasks.withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "11"
         }
+        kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
 }

--- a/jooby/build.gradle.kts
+++ b/jooby/build.gradle.kts
@@ -1,0 +1,67 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
+
+plugins {
+    val joobyVersion = "2.9.5"
+
+    kotlin("jvm")
+    kotlin("kapt")
+
+    id("io.jooby.run") version joobyVersion
+    id("com.google.osdetector") version "1.6.2"
+    id("io.spring.dependency-management") version "1.0.10.RELEASE"
+    id("com.github.johnrengelman.shadow") version "6.1.0"
+
+    application
+}
+apply(plugin = "io.ebean")
+
+application {
+    group = "org.fosdem.steinhauer.demo.jooby"
+    version = "1.0.0"
+    mainClass.set("org.fosdem.steinhauer.demo.jooby.AppKt")
+    mainClassName = mainClass.get() //needed by shadowJar
+}
+
+val joobyVersion = "2.9.5"
+val koinVersion = "2.2.2"
+val ebeanVersion = "12.6.5"
+
+configure<DependencyManagementExtension> {
+    imports {
+        mavenBom("io.jooby:jooby-bom:$joobyVersion")
+    }
+}
+
+dependencies {
+    api(project(":shared"))
+    api("io.ebean:ebean-querybean:${ebeanVersion}")
+
+    kapt("io.jooby:jooby-apt")
+
+    implementation("io.jooby:jooby-netty")
+    implementation ("io.jooby:jooby-jackson:$joobyVersion")
+    implementation("ch.qos.logback:logback-classic")
+
+    implementation("org.koin:koin-core:$koinVersion")
+
+}
+
+kapt {
+    arguments {
+        arg("jooby.incremental", true)
+        arg("jooby.services", true)
+        arg("jooby.debug", false)
+    }
+}
+
+tasks {
+    named<ShadowJar>("shadowJar") {
+        archiveBaseName.set("app")
+        mergeServiceFiles()
+        manifest {
+            attributes(mapOf("Main-Class" to application.mainClass.get()))
+        }
+    }
+
+}

--- a/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/App.kt
+++ b/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/App.kt
@@ -1,0 +1,38 @@
+package org.fosdem.steinhauer.demo.jooby
+
+import io.jooby.Kooby
+import io.jooby.json.JacksonModule
+import io.jooby.runApp
+import org.fosdem.steinhauer.demo.jooby.controller.ArticleController
+import org.fosdem.steinhauer.demo.jooby.repository.ArticleRepository
+import org.fosdem.steinhauer.demo.jooby.repository.FosdemArticleRepository
+import org.fosdem.steinhauer.demo.jooby.service.ArticleService
+import org.fosdem.steinhauer.demo.jooby.service.FosdemArticleService
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+@KoinApiExtension
+class App : Kooby({
+
+    install(JacksonModule())
+    mvc(ArticleController())
+
+})
+
+@KoinApiExtension
+fun main(args: Array<String>) {
+    startKoin {
+        printLogger()
+        modules(articleModule)
+    }
+
+    runApp(args, App::class)
+}
+
+@Suppress("USELESS_CAST")
+@OptIn(KoinApiExtension::class)
+val articleModule = module {
+    single { FosdemArticleService() as ArticleService }
+    single { FosdemArticleRepository() as ArticleRepository }
+}

--- a/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/controller/ArticleController.kt
+++ b/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/controller/ArticleController.kt
@@ -1,0 +1,21 @@
+package org.fosdem.steinhauer.demo.jooby.controller
+
+import io.jooby.annotations.GET
+import io.jooby.annotations.Path
+import org.fosdem.steinhauer.demo.domain.Article
+import org.fosdem.steinhauer.demo.jooby.service.ArticleService
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+@KoinApiExtension
+@Path("/article/")
+class ArticleController: KoinComponent {
+
+    private val articleService by inject<ArticleService>()
+
+    @GET
+    fun getAllArticles(): List<Article> {
+        return articleService.getAllArticles()
+    }
+}

--- a/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/repository/ArticleRepository.kt
+++ b/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/repository/ArticleRepository.kt
@@ -1,0 +1,16 @@
+package org.fosdem.steinhauer.demo.jooby.repository
+
+import org.fosdem.steinhauer.demo.domain.Article
+import org.fosdem.steinhauer.demo.domain.query.QArticle
+
+interface ArticleRepository {
+    fun getAllArticles(): List<Article>
+}
+
+class FosdemArticleRepository: ArticleRepository {
+
+    override fun getAllArticles(): List<Article> {
+        return QArticle().findList()
+    }
+
+}

--- a/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/service/ArticleService.kt
+++ b/jooby/src/main/kotlin/org/fosdem/steinhauer/demo/jooby/service/ArticleService.kt
@@ -1,0 +1,19 @@
+package org.fosdem.steinhauer.demo.jooby.service
+
+import org.fosdem.steinhauer.demo.domain.Article
+import org.fosdem.steinhauer.demo.jooby.repository.ArticleRepository
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface ArticleService {
+    fun getAllArticles(): List<Article>
+}
+
+@KoinApiExtension
+class FosdemArticleService: ArticleService, KoinComponent {
+
+    private val articleRepository by inject<ArticleRepository>()
+
+    override fun getAllArticles(): List<Article> = articleRepository.getAllArticles()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "this-spring-shall-be-challenged"
-include("spring", "ktor", "micronaut", "jooby")
+include("shared", "spring", "ktor", "micronaut", "jooby")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm")
+    kotlin("kapt")
+
+}
+apply(plugin = "io.ebean")
+
+val ebeanVersion = "12.6.5"
+val flywayVersion = "7.2.0"
+val postgresqlVersion = "42.2.18"
+
+dependencies {
+    kapt("io.ebean:kotlin-querybean-generator:${ebeanVersion}")
+
+    implementation("javax.persistence:javax.persistence-api:2.2")
+    implementation("io.ebean:ebean:${ebeanVersion}")
+    implementation("io.ebean:ebean-querybean:${ebeanVersion}")
+    implementation("org.flywaydb:flyway-core:${flywayVersion}")
+    implementation("org.postgresql:postgresql:${postgresqlVersion}")
+
+}

--- a/shared/src/main/kotlin/org/fosdem/steinhauer/demo/domain/Article.kt
+++ b/shared/src/main/kotlin/org/fosdem/steinhauer/demo/domain/Article.kt
@@ -1,4 +1,4 @@
-package org.fosdem.steinhauer.demo.spring.domain
+package org.fosdem.steinhauer.demo.domain
 
 import java.time.Instant
 import javax.persistence.*

--- a/shared/src/main/kotlin/org/fosdem/steinhauer/demo/domain/BaseModel.kt
+++ b/shared/src/main/kotlin/org/fosdem/steinhauer/demo/domain/BaseModel.kt
@@ -1,4 +1,4 @@
-package org.fosdem.steinhauer.demo.spring.domain
+package org.fosdem.steinhauer.demo.domain
 
 import io.ebean.Model
 import io.ebean.annotation.WhenCreated

--- a/shared/src/main/resources/application.yml
+++ b/shared/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+logging:
+  level:
+    org:
+      flywaydb: INFO
+    io:
+      ebean:
+        SQL: DEBUG
+        TXN: DEBUG
+
+datasource:
+  db:
+    username: fosdem
+    password: "Fosdem.2021"
+    databaseUrl: jdbc:postgresql://localhost:5432/fosdem21

--- a/shared/src/main/resources/ebean.mf
+++ b/shared/src/main/resources/ebean.mf
@@ -1,0 +1,4 @@
+entity-packages: org.fosdem.steinhauer.demo.spring.org.fosdem.steinhauer.demo.domain
+querybean-packages: org.fosdem.steinhauer.demo.spring.org.fosdem.steinhauer.demo.domain
+transactional-packages: org.fosdem.steinhauer.demo
+profile-location: true

--- a/spring/build.gradle.kts
+++ b/spring/build.gradle.kts
@@ -8,22 +8,15 @@ plugins {
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
 }
 
-apply(plugin = "io.ebean")
-
 val ebeanVersion = "12.6.5"
-val flywayVersion = "7.2.0"
-val postgresqlVersion = "42.2.18"
 
 dependencies {
     kapt("org.springframework.boot:spring-boot-configuration-processor")
-    kapt("io.ebean:kotlin-querybean-generator:${ebeanVersion}")
 
+    api(project(":shared"))
+    api("io.ebean:ebean-querybean:${ebeanVersion}")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework:spring-jdbc")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("io.ebean:ebean:${ebeanVersion}")
-    implementation("io.ebean:ebean-querybean:${ebeanVersion}")
-    implementation("org.flywaydb:flyway-core:${flywayVersion}")
-    implementation("org.postgresql:postgresql:${postgresqlVersion}")
 }

--- a/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/controller/ArticleController.kt
+++ b/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/controller/ArticleController.kt
@@ -1,6 +1,6 @@
 package org.fosdem.steinhauer.demo.spring.controller
 
-import org.fosdem.steinhauer.demo.spring.domain.Article
+import org.fosdem.steinhauer.demo.domain.Article
 import org.fosdem.steinhauer.demo.spring.service.ArticleService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping

--- a/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/repository/ArticleRepository.kt
+++ b/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/repository/ArticleRepository.kt
@@ -1,12 +1,12 @@
 package org.fosdem.steinhauer.demo.spring.repository
 
-import org.fosdem.steinhauer.demo.spring.domain.Article
-import org.fosdem.steinhauer.demo.spring.domain.query.QArticle
+import org.fosdem.steinhauer.demo.domain.Article
+import org.fosdem.steinhauer.demo.domain.query.QArticle
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Repository
 
 @Repository
-class ArticleRepository @Autowired constructor() {
+class ArticleRepository {
 
     fun getAllArticle(): List<Article> = QArticle().findList()
 

--- a/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/service/ArticleService.kt
+++ b/spring/src/main/kotlin/org/fosdem/steinhauer/demo/spring/service/ArticleService.kt
@@ -1,6 +1,6 @@
 package org.fosdem.steinhauer.demo.spring.service
 
-import org.fosdem.steinhauer.demo.spring.domain.Article
+import org.fosdem.steinhauer.demo.domain.Article
 import org.fosdem.steinhauer.demo.spring.repository.ArticleRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service

--- a/spring/src/main/resources/ebean.mf
+++ b/spring/src/main/resources/ebean.mf
@@ -1,4 +1,0 @@
-entity-packages: org.fosdem.steinhauer.demo.spring.domain
-querybean-packages: org.fosdem.steinhauer.demo.spring.domain
-transactional-packages: org.fosdem.steinhauer.demo
-profile-location: true


### PR DESCRIPTION
This brings quite a few changes on the table:

1. Domain model as shared code
To avoid some duplication, the ebean based domain model will be in the new `shared` project.
This comes with quite some changes on the existing Spring app and in the build scripts.

2. Jooby spike works!
All code needed to have the same functionality as we have with Spring is in here now.

3. Koin as DI framework
We will use Koin for all framework approaches but Spring. This commit show how it is done for Jooby already 🎉