### PR TITLE
Docker-fy Jooby

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,3 +22,32 @@ CREATE DATABASE "fosdem21";
 CREATE USER "fosdem" WITH ENCRYPTED PASSWORD 'Fosdem.2021';
 GRANT ALL PRIVILEGES ON DATABASE "fosdem21" TO "fosdem";
 ----
+
+== Docker
+We can create Docker images and run the demos independently this way.
+Each subproject contains a _Dockerfile_ which we use to create the images.
+
+[NOTE]
+====
+The _Dockerfile_ expects the ready-to-use JAR file in the _build_ folder structure. So please run `gradle clean build` before attempting to create the image
+====
+
+=== Pre-built images
+There are pre-built images available on Docker Hub. Here is the list:
+
+- https://hub.docker.com/r/daincredibleholg/fosdem21-demo-jooby[Jooby Demo]
+
+=== Configuration
+All images accept the following parameters:
+
+.Docker container variables
+|===
+| Name | Description | Default
+
+| DB_HOST | Hostname of the target DB | `localhost`
+| DB_NAME | Schema name | `fosdem`
+| DB_USERNAME | Username to auth at DB | `fosdem`
+| DB_PASSWORD | Password to auth at DB | `fosdem`
+|===
+
+Check out https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file[Docker's documentation] on how to set them.

--- a/jooby/Dockerfile
+++ b/jooby/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11-jdk-slim
+WORKDIR /fosdem-demo
+COPY build/libs/app-1.0.0-all.jar app.jar
+COPY docker/application.properties /fosdem-demo/application.properties
+COPY docker/runner.sh /
+
+RUN chmod +x /runner.sh
+
+EXPOSE 8080
+CMD ["/runner.sh"]

--- a/jooby/docker/application.properties
+++ b/jooby/docker/application.properties
@@ -1,0 +1,7 @@
+logging.level.org.flywaydb=INFO
+logging.io.ebean.SQL=INFO
+logging.io.ebean.TXN=INFO
+
+datasource.db.databaseUrl: jdbc:postgresql://__DB_HOST__:5432/__DB_NAME__
+datasource.db.username=__DB_USERNAME__
+datasource.db.password=__DB_PASSWORD__

--- a/jooby/docker/runner.sh
+++ b/jooby/docker/runner.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+DB_HOST=${DB_HOST:-'localhost'}
+DB_NAME=${DB_NAME:-'fosdem'}
+DB_USERNAME=${DB_USERNAME:-'fosdem'}
+DB_PASSWORD=${DB_PASSWORD:-'fosdem'}
+
+cd /fosdem-demo
+
+sed -i "s/__DB_HOST__/${DB_HOST}/" application.properties
+sed -i "s/__DB_NAME__/${DB_NAME}/" application.properties
+sed -i "s/__DB_USERNAME__/${DB_USERNAME}/" application.properties
+sed -i "s/__DB_PASSWORD__/${DB_PASSWORD}/" application.properties
+
+java -jar app.jar

--- a/shared/src/main/resources/ebean.mf
+++ b/shared/src/main/resources/ebean.mf
@@ -1,4 +1,0 @@
-entity-packages: org.fosdem.steinhauer.demo.spring.org.fosdem.steinhauer.demo.domain
-querybean-packages: org.fosdem.steinhauer.demo.spring.org.fosdem.steinhauer.demo.domain
-transactional-packages: org.fosdem.steinhauer.demo
-profile-location: true


### PR DESCRIPTION
A bit rude, but it works, the Docker-isation of the Jooby demo.

Use the _Dockerfile_ in _jooby/_ to create an image. The image itself accepts `DB_NAME`, `DB_HOST`, `DB_USERNAME` and `DB_PASSWORD` as variable and generates the relevant ebean configuration file.
The current build of the image is also available on [Docker Hub](https://hub.docker.com/r/daincredibleholg/fosdem21-demo-jooby).