### PR TITLE
Docker-fy ktor

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,7 @@ The _Dockerfile_ expects the ready-to-use JAR file in the _build_ folder structu
 There are pre-built images available on Docker Hub. Here is the list:
 
 - https://hub.docker.com/r/daincredibleholg/fosdem21-demo-jooby[Jooby Demo]
+- https://hub.docker.com/r/daincredibleholg/fosdem21-demo-ktor[Ktor Demo]
 
 === Configuration
 All images accept the following parameters:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.4.21-2" apply false
+    id("com.github.johnrengelman.shadow") version "6.1.0" apply false
 }
 
 repositories {

--- a/jooby/build.gradle.kts
+++ b/jooby/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("io.jooby.run") version joobyVersion
     id("com.google.osdetector") version "1.6.2"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
-    id("com.github.johnrengelman.shadow") version "6.1.0"
+    id("com.github.johnrengelman.shadow")
 
     application
 }

--- a/ktor/Dockerfile
+++ b/ktor/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:11-jdk-slim
+WORKDIR /fosdem-demo
+COPY build/libs/app-1.0.0-all.jar app.jar
+COPY docker/application.properties /fosdem-demo/application.properties
+COPY docker/runner.sh /
+
+RUN chmod +x /runner.sh
+
+EXPOSE 8080
+CMD ["/runner.sh"]

--- a/ktor/build.gradle.kts
+++ b/ktor/build.gradle.kts
@@ -1,5 +1,9 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     kotlin("jvm")
+    id("com.github.johnrengelman.shadow")
+
     application
 }
 
@@ -27,5 +31,21 @@ dependencies {
 }
 
 application {
+    group = "org.fosdem.steinhauer.demo.ktor"
+    version = "1.0.0"
     mainClass.set("io.ktor.server.netty.EngineMain")
+    mainClassName = mainClass.get() //needed by shadowJar
+
+}
+
+
+tasks {
+    named<ShadowJar>("shadowJar") {
+        archiveBaseName.set("app")
+        mergeServiceFiles()
+        manifest {
+            attributes(mapOf("Main-Class" to application.mainClass.get()))
+        }
+    }
+
 }

--- a/ktor/docker/application.properties
+++ b/ktor/docker/application.properties
@@ -1,0 +1,7 @@
+logging.level.org.flywaydb=INFO
+logging.io.ebean.SQL=INFO
+logging.io.ebean.TXN=INFO
+
+datasource.db.databaseUrl: jdbc:postgresql://__DB_HOST__:5432/__DB_NAME__
+datasource.db.username=__DB_USERNAME__
+datasource.db.password=__DB_PASSWORD__

--- a/ktor/docker/runner.sh
+++ b/ktor/docker/runner.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+DB_HOST=${DB_HOST:-'localhost'}
+DB_NAME=${DB_NAME:-'fosdem'}
+DB_USERNAME=${DB_USERNAME:-'fosdem'}
+DB_PASSWORD=${DB_PASSWORD:-'fosdem'}
+
+cd /fosdem-demo
+
+sed -i "s/__DB_HOST__/${DB_HOST}/" application.properties
+sed -i "s/__DB_NAME__/${DB_NAME}/" application.properties
+sed -i "s/__DB_USERNAME__/${DB_USERNAME}/" application.properties
+sed -i "s/__DB_PASSWORD__/${DB_PASSWORD}/" application.properties
+
+# https://ktor.io/docs/docker.html#prepare-docker-image
+java -server -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication -jar app.jar

--- a/micronaut/build.gradle.kts
+++ b/micronaut/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     kotlin("kapt")
     kotlin("plugin.allopen") version "1.4.21-2"
-    id("com.github.johnrengelman.shadow") version "6.1.0"
+    id("com.github.johnrengelman.shadow")
     id("io.micronaut.application") version "1.2.0"
 }
 


### PR DESCRIPTION
This brings the Docker-isation to the ktor project.

As ktor relies on `shadowJar` as well, the Gradle plugin definition goes into the root project build file and gets applied in all necessary projects (essentially all but Spring).